### PR TITLE
Library fails to install

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -47,7 +47,7 @@ except ImportError:
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
 DEFAULT_VERSION = "0.6.14"
-DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
+DEFAULT_URL = "https://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
 SETUPTOOLS_PKG_INFO = """\

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@
 import os
 import re
 
-from distribute_setup import use_setuptools; use_setuptools()
+try:
+    import setuptools
+except ImportError:
+    from distribute_setup import use_setuptools
+    use_setuptools()
+
 from setuptools import setup
 
 
@@ -53,4 +58,3 @@ setup(
         'console_scripts': ['hotwatch = hotwatch.cli:main'],
     },
 )
-


### PR DESCRIPTION
PyPI appears to have made [a change](https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html) requiring all access to be over HTTPS.

```
$ env/bin/pip install hotwatch
Collecting hotwatch
  Downloading hotwatch-0.1.2.tar.gz
    Complete output from command python setup.py egg_info:
    Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.14.tar.gz
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-V37Mq1/hotwatch/setup.py", line 7, in <module>
        from distribute_setup import use_setuptools; use_setuptools()
      File "/tmp/pip-build-V37Mq1/hotwatch/distribute_setup.py", line 145, in use_setuptools
        return _do_download(version, download_base, to_dir, download_delay)
      File "/tmp/pip-build-V37Mq1/hotwatch/distribute_setup.py", line 124, in _do_download
        to_dir, download_delay)
      File "/tmp/pip-build-V37Mq1/hotwatch/distribute_setup.py", line 193, in download_setuptools
        src = urlopen(url)
      File "/usr/lib/python2.7/urllib2.py", line 154, in urlopen
        return opener.open(url, data, timeout)
      File "/usr/lib/python2.7/urllib2.py", line 435, in open
        response = meth(req, response)
      File "/usr/lib/python2.7/urllib2.py", line 548, in http_response
        'http', request, response, code, msg, hdrs)
      File "/usr/lib/python2.7/urllib2.py", line 473, in error
        return self._call_chain(*args)
      File "/usr/lib/python2.7/urllib2.py", line 407, in _call_chain
        result = func(*args)
      File "/usr/lib/python2.7/urllib2.py", line 556, in http_error_default
        raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
    urllib2.HTTPError: HTTP Error 403: SSL is required

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-V37Mq1/hotwatch/
```

This is very similar to [this PR](https://github.com/richardhenry/hotqueue/pull/20) on `hotqueue`, and the fix is very similar.

I've also replicated a change you made to `hotqueue` whereby `distribute_setup` is only called if it needs to be; I think this is the correct thing to do. I've also corrected the URL to be HTTPS.